### PR TITLE
fix(renderer):  fixing renderer

### DIFF
--- a/workspaces/storybook-aurelia2-renderer/src/render.ts
+++ b/workspaces/storybook-aurelia2-renderer/src/render.ts
@@ -11,7 +11,7 @@ export const render: ArgsStoryFn<AureliaRenderer> = (args, context) => {
         );
     }
 
-    return { Component, props: args };
+    return { Component, props: args, template: '' };
 };
 
 function aureliaRender(
@@ -25,7 +25,7 @@ function aureliaRender(
 
     const result = context.storyFn();
 
-    canvasElement.innerHTML += result.template;
+    canvasElement.innerHTML = result.template;
 
     const aurelia = new Aurelia();
 
@@ -49,4 +49,3 @@ export function renderToCanvas(
 
     aureliaRender(context, canvasElement);
 }
-


### PR DESCRIPTION
1. Fixes typing issue in render because it expects a `template` property to be returned. We just return an empty string. There might be a better way to sort this out.

2. Inside of the `aureliaRender` function we were concatenating the result to the canvas element, which meant if you tabbed between story variants, it would just duplicate what was there (add to it and not reset).